### PR TITLE
Integrate new StateEstimator skeleton

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -296,6 +296,16 @@ class LoggingConfig(BaseModel):
     log_format: str = '%(asctime)s - [%(name)s] %(levelname)s - %(message)s'
 
 
+class StateEstimatorConfig(BaseModel):
+    """Konfiguration für den StateEstimator (AEKF)."""
+    enabled: bool = Field(True, description="Aktiviert oder deaktiviert die Zustandsschätzung.")
+    state_dimension: int = Field(20, ge=1, description="Dimension n des Systemzustandsvektors x_t.")
+    measurement_dimension: int = Field(50, ge=1, description="Dimension p des Messvektors y_t.")
+    ensemble_size: int = Field(100, ge=10, description="Anzahl der Partikel (Ensemble-Members) N für den AEKF.")
+    initial_process_noise_q: float = Field(0.01, gt=0, description="Initialer Skalar für die Prozessrauschen-Kovarianz Q.")
+    initial_measurement_noise_r: float = Field(0.1, gt=0, description="Initialer Skalar für die Messrauschen-Kovarianz R.")
+
+
 class EconomicModelConfig(BaseModel):
     """Minimal container for high level model sub-configs used in tests."""
     producer_params: ProducerParamsConfig = Field(default_factory=ProducerParamsConfig)
@@ -315,6 +325,7 @@ class SimulationConfig(BaseModel):
     regional_config: RegionalConfig = Field(default_factory=RegionalConfig)
     admm_config: ADMMConfig = Field(default_factory=ADMMConfig)
     logging_config: LoggingConfig = Field(default_factory=LoggingConfig)
+    state_estimator_config: StateEstimatorConfig = Field(default_factory=StateEstimatorConfig)
 
     # --- Grundlegende Simulation ---
     simulation_name: str = "Impaler_Default_Run"
@@ -339,7 +350,7 @@ class SimulationConfig(BaseModel):
 
     # --- Simulation-Stages ---
     stages: List[str] = [
-        "resource_regen", "need_estimation", "infrastructure_development",
+        "resource_regen", "state_estimation", "need_estimation", "infrastructure_development",
         "system5_policy", "system4_strategic_planning", "system4_tactical_planning",
         "system3_aggregation", "system2_coordination", "system3_feedback",
         "system1_operations", "local_production_planning", "admm_update",

--- a/core/state_estimator.py
+++ b/core/state_estimator.py
@@ -1,0 +1,60 @@
+# impaler/core/state_estimator.py
+"""
+Implementiert den Adaptive Ensemble Kalman Filter (AEKF) zur Schätzung des
+globalen Systemzustands basierend auf verrauschten Messdaten.
+"""
+
+import numpy as np
+import logging
+from typing import Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - nur für Typprüfung
+    from .model import EconomicModel
+
+
+class StateEstimator:
+    """Führt eine Zustandsschätzung mittels AEKF durch."""
+
+    def __init__(self, model: 'EconomicModel'):
+        """Initialisiert den StateEstimator."""
+        self.model = model
+        self.logger = model.logger.getChild('StateEstimator')
+        self.config = model.config.state_estimator_config
+
+        self.n = self.config.state_dimension
+        self.p = self.config.measurement_dimension
+        self.N = self.config.ensemble_size
+
+        self.Q = np.eye(self.n) * self.config.initial_process_noise_q
+        self.R = np.eye(self.p) * self.config.initial_measurement_noise_r
+
+        self.ensemble = np.random.multivariate_normal(
+            np.zeros(self.n), np.eye(self.n), self.N
+        )
+
+        self.logger.info(
+            f"StateEstimator initialisiert (State Dim: {self.n}, Meas Dim: {self.p}, Ensemble Size: {self.N})."
+        )
+
+    def _prediction_step(self, u_t_minus_1: np.ndarray) -> None:
+        """Führt den Prädiktionsschritt des AEKF aus."""
+        self.logger.debug("AEKF: Prädiktionsschritt...")
+        # TODO: Implementiere die eigentliche Prozessmodell-Logik
+        pass
+
+    def _measurement_update_step(self, y_t: np.ndarray) -> None:
+        """Führt den Korrekturschritt des AEKF aus."""
+        self.logger.debug(f"AEKF: Korrekturschritt mit Messung y_t (Shape: {y_t.shape})...")
+        # TODO: Implementiere die eigentliche Messupdate-Logik
+        pass
+
+    def estimate_state(self, u_t_minus_1: np.ndarray, y_t: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Führt einen kompletten Schätzzyklus aus."""
+        self._prediction_step(u_t_minus_1)
+        self._measurement_update_step(y_t)
+
+        mu_t = np.mean(self.ensemble, axis=0)
+        P_t = np.cov(self.ensemble, rowvar=False)
+
+        self.logger.info("Neuer Systemzustand (\u03bc_t, P_t) geschätzt.")
+        return mu_t, P_t


### PR DESCRIPTION
## Summary
- introduce `StateEstimator` stub implementing AEKF structure
- extend configuration with `StateEstimatorConfig`
- wire estimator into `EconomicModel` and stage flow
- register new `state_estimation` stage before planning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, fixture errors)*

------
https://chatgpt.com/codex/tasks/task_e_684815cf29e4832f9d6352f2bb59da24