### PR TITLE
Align stages with RADRO‑ADMM plan

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -33,19 +33,21 @@ default_config = SimulationConfig().to_dict()
 # but we keep this list for backward compatibility
 SIMULATION_STAGES = [
     "resource_regen",              # Resource agent regeneration
+    "state_estimation",            # Estimate global/agent state
     "need_estimation",             # Update consumer needs
     "infrastructure_development",  # Update infrastructure capacities
     "system5_policy",              # High-level policy adjustments
-    "system4_strategic_planning",  # Long-term planning
+    "system4_strategic_planning_admm",  # Long-term planning with ADMM
     "system4_tactical_planning",   # Medium-term planning
     "system3_aggregation",         # Aggregate regional data
     "system2_coordination",        # Inter-regional coordination
     "system3_feedback",            # Feedback to regions
+    "broadcast_plan_and_prices",   # Share global plan and price signals
     "system1_operations",          # Operational execution preparation
     "local_production_planning",   # Producer-level planning
+    "local_rl_execution",          # Local RL-driven decisions
     "admm_update",                 # ADMM constraint resolution
     "production_execution",        # Actual production execution
-    "distribution",                # Product distribution
     "consumption",                 # Consumer consumption
     "environmental_impact",        # Calculate environmental impacts
     "technology_progress",         # Update technology levels

--- a/core/config.py
+++ b/core/config.py
@@ -350,14 +350,30 @@ class SimulationConfig(BaseModel):
 
     # --- Simulation-Stages ---
     stages: List[str] = [
-        "resource_regen", "state_estimation", "need_estimation", "infrastructure_development",
-        "system5_policy", "system4_strategic_planning", "system4_tactical_planning",
-        "system3_aggregation", "system2_coordination", "system3_feedback",
-        "system1_operations", "local_production_planning", "admm_update",
-        "production_execution", "distribution", "consumption",
-        "environmental_impact", "technology_progress", "crisis_management",
-        "welfare_assessment", "learning_adaptation", "vsm_reconfiguration",
-        "bookkeeping"
+        "resource_regen",
+        "state_estimation",
+        "need_estimation",
+        "infrastructure_development",
+        "system5_policy",
+        "system4_strategic_planning_admm",
+        "system4_tactical_planning",
+        "system3_aggregation",
+        "system2_coordination",
+        "system3_feedback",
+        "broadcast_plan_and_prices",
+        "system1_operations",
+        "local_production_planning",
+        "local_rl_execution",
+        "admm_update",
+        "production_execution",
+        "consumption",
+        "environmental_impact",
+        "technology_progress",
+        "crisis_management",
+        "welfare_assessment",
+        "learning_adaptation",
+        "vsm_reconfiguration",
+        "bookkeeping",
     ]
 
     # --- Parallelisierung ---


### PR DESCRIPTION
## Summary
- update `SimulationConfig.stages` ordering
- sync `SIMULATION_STAGES` constant with new RADRO‑ADMM flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684828464214832fb3ba6351438f0789